### PR TITLE
Fix naming of html elements in error messages

### DIFF
--- a/test/index-tests.js
+++ b/test/index-tests.js
@@ -5,7 +5,7 @@ import React from 'react/addons'
 const { TestUtils } = React.addons
 const { expect } = chai
 
-const Super = React.createClass({
+const SuperDuper = React.createClass({
   displayName: 'SuperDuper',
   propTypes: { children: React.PropTypes.any },
   render() { return <div className="super-duper">{this.props.children}</div> },
@@ -18,23 +18,23 @@ const Sub = React.createClass({
 
 describe('.have.component(Component)', () => {
   it('should find find given component in rendered react component', () => {
-    const component = TestUtils.renderIntoDocument(<div><Super /></div>)
-    expect(component).to.have.component(Super)
+    const component = TestUtils.renderIntoDocument(<div><SuperDuper /></div>)
+    expect(component).to.have.component(SuperDuper)
   })
 
   it('should find find given component in div component', () => {
-    expect(<div><Super /></div>).to.have.component(Super)
+    expect(<div><SuperDuper /></div>).to.have.component(SuperDuper)
   })
 
   it('should find find given component in react component', () => {
-    expect(<Super><Sub /></Super>).to.have.component(Sub)
+    expect(<SuperDuper><Sub /></SuperDuper>).to.have.component(Sub)
   })
 
   describe('when it does not find given component in react component', () => {
     it('should throw', () => {
       expect(() => {
-        expect(<blink>hi</blink>).to.have.component(Super)
-      }).to.throw('to have component \'SuperDuper\'')
+        expect(<blink>hi</blink>).to.have.component(SuperDuper)
+      }).to.throw('\'blink\' to have component \'SuperDuper\'')
     })
   })
 })


### PR DESCRIPTION
The error message has "undefined" instead of the name of the html
element.
